### PR TITLE
Ensure chatbot manager validates AI configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,8 +150,10 @@ Application de gestion d'inventaire sophistiquée avec **IA avancée**, **recher
 ### Prérequis
 - **Python 3.11+**
 - **Compte Supabase** (gratuit)
-- **Clé API OpenAI** (GPT-4)
+- **Clé API OpenAI** (GPT-4) **ou** module `ai_engine` fournissant un client compatible
 - **Compte Gmail** (pour notifications)
+
+> ⚠️ Le module `chatbot_manager.py` vérifie explicitement la présence d'un module `ai_engine` ou de la variable d'environnement `OPENAI_API_KEY`. Sans l'une de ces options, les fonctionnalités IA retourneront une erreur indiquant que la configuration est manquante.
 
 ### Installation Locale
 


### PR DESCRIPTION
## Summary
- detect the presence of the custom `ai_engine` module or the `OPENAI_API_KEY` before wiring the chatbot AI client and keep track of configuration errors
- guard AI-dependent helpers so they raise a clear runtime error that bubbles up as structured error responses when no engine is configured
- document in the README that either an `ai_engine` module or the `OPENAI_API_KEY` environment variable is now required for chatbot features

## Testing
- python3 -m compileall -f chatbot_manager.py

------
https://chatgpt.com/codex/tasks/task_b_68c9802917e48327bf622be8dcfbc643